### PR TITLE
Update for PureScript 0.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,28 +13,28 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1.0-bower-cache-{{ .Branch }}-{{ checksum "bower.json" }}
-            - v1.0-bower-cache-{{ .Branch }}
-            - v1.0-bower-cache
+            - v1.1-bower-cache-{{ .Branch }}-{{ checksum "bower.json" }}
+            - v1.1-bower-cache-{{ .Branch }}
+            - v1.1-bower-cache
 
       - restore_cache:
           keys:
-            - v1.0-npm-cache-{{ .Branch }}-{{ checksum "package.json" }}
-            - v1.0-npm-cache-{{ .Branch }}
-            - v1.0-npm-cache
+            - v1.1-npm-cache-{{ .Branch }}-{{ checksum "package.json" }}
+            - v1.1-npm-cache-{{ .Branch }}
+            - v1.1-npm-cache
 
       - run:
           name: Install dependencies from NPM and Bower
           command: npm i && bower i
 
       - save_cache:
-          key: v1.0-bower-cache-{{ .Branch }}-{{ checksum "bower.json" }}
+          key: v1.1-bower-cache-{{ .Branch }}-{{ checksum "bower.json" }}
           paths:
             - ~/fuzzy/bower_components
             - ~/fuzzy/output
 
       - save_cache:
-          key: v1.0-npm-cache-{{ .Branch }}-{{ checksum "package.json" }}
+          key: v1.1-npm-cache-{{ .Branch }}-{{ checksum "package.json" }}
           paths:
             - ~/fuzzy/node_modules
 

--- a/bower.json
+++ b/bower.json
@@ -25,22 +25,21 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.1.1",
-    "purescript-console": "^3.0.0",
-    "purescript-strings": "^3.4.0",
-    "purescript-foldable-traversable": "^3.7.1",
-    "purescript-tuples": "^4.1.0",
-    "purescript-stringutils": "^0.0.7",
-    "purescript-maps": "^3.6.0",
-    "purescript-newtype": "^2.0.0",
-    "purescript-generics-rep": "^5.4.0",
-    "purescript-rationals": "^4.0.0",
-    "purescript-quickcheck": "^4.6.1"
+    "purescript-prelude": "^4.0.1",
+    "purescript-strings": "^4.0.0",
+    "purescript-foldable-traversable": "^4.0.0",
+    "purescript-tuples": "^5.0.0",
+    "purescript-ordered-collections": "^1.0.0",
+    "purescript-newtype": "^3.0.0",
+    "purescript-generics-rep": "^6.0.0",
+    "purescript-rationals": "^5.0.0",
+    "purescript-foreign-object": "^1.0.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^3.0.0",
-    "purescript-test-unit": "^13.0.0",
-    "purescript-quickcheck-laws": "^3.0.1",
-    "purescript-datetime": "^3.4.1"
+    "purescript-psci-support": "^4.0.0",
+    "purescript-test-unit": "^14.0.0",
+    "purescript-datetime": "^4.0.0",
+    "purescript-strongcheck": "^4.1.0",
+    "purescript-strongcheck-laws": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "test": "pulp test"
   },
   "devDependencies": {
-    "pulp": "^12.0.1",
-    "purescript": "^0.11.7"
+    "pulp": "^12.3.0",
+    "purescript": "^0.12.0"
   }
 }


### PR DESCRIPTION
This PR updates the repository to use PureScript 0.12. It removes dependencies on `stringutils` in favor of `purescript-strings`. Will require a bumped release.